### PR TITLE
MeGyro: Properly align with gravity on startup

### DIFF
--- a/src/MeGyro.cpp
+++ b/src/MeGyro.cpp
@@ -180,12 +180,16 @@ void MeGyro::begin(void)
   gyrZoffs = 0;
   Wire.begin();
   delay(200);
-  writeReg(0x6b, 0x00);//close the sleep mode
+  writeReg(0x6b, 0x00);  //close the sleep mode
   delay(100);
-  writeReg(0x1a, 0x01);//configurate the digital low pass filter
-  writeReg(0x1b, 0x08);//set the gyro scale to 500 deg/s
+  writeReg(0x1a, 0x01);  //configurate the digital low pass filter
+  writeReg(0x1b, 0x08);  //set the gyro scale to 500 deg/s
   delay(100);
-  deviceCalibration();
+  deviceCalibration();   //  Determine gyro drift
+  update();              //  Read data
+  double ax, ay;
+  gx = ax = atan2(accX, sqrt( pow(accY, 2) + pow(accZ, 2) ) ) * 180 / 3.1415926;  //  Initialize angle
+  gy = ay = atan2(accY, sqrt( pow(accX, 2) + pow(accZ, 2) ) ) * 180 / 3.1415926;  //  Initialize angle
 }
 
 /**

--- a/src/MeGyro.cpp
+++ b/src/MeGyro.cpp
@@ -180,10 +180,10 @@ void MeGyro::begin(void)
   gyrZoffs = 0;
   Wire.begin();
   delay(200);
-  writeReg(0x6b, 0x00);  //close the sleep mode
+  writeReg(0x6b, 0x00);//close the sleep mode
   delay(100);
-  writeReg(0x1a, 0x01);  //configurate the digital low pass filter
-  writeReg(0x1b, 0x08);  //set the gyro scale to 500 deg/s
+  writeReg(0x1a, 0x01);//configurate the digital low pass filter
+  writeReg(0x1b, 0x08);//set the gyro scale to 500 deg/s
   delay(100);
   deviceCalibration();   //  Determine gyro drift
   update();              //  Read data


### PR DESCRIPTION
Clean up pull request #1 by clplaneguy. Quoting from the original pull request:

> My project is a balancing robot. I started with the firmware. It has the balance code in it. I am studying and learning it. Then gradually replacing their code with mine. I have found a problem with MeGyro. In BEGIN all values are initialized to zero. In UPDATE the values are linked to gravity. So, my robot is sitting on the table and I start the process. All values are set to zero. But my balancing robot is at 90 degrees. I have it set to balance around zero and shut down above 45 degrees. So, it thinks it is at zero and runs off the table. To properly initialize the angle, I have to loop through 500 UPDATES in SETUP. That sets angle to 90 degrees. A better way would be to get BEGIN to properly align the angle with gravity on startup. I have started typing in the correction code.

Separate pull requests should be opened for each separate issue. This is the first one.